### PR TITLE
fix(wave): prevent multiple wave spawns causing incorrect wave numbers

### DIFF
--- a/src/game-scene.ts
+++ b/src/game-scene.ts
@@ -37,6 +37,7 @@ export class GameScene {
   private synthesisSlot: FoodType[] = [];
   private shootCooldown: number = 0;
   private readonly shootCooldownTime: number = 0.2; // 200ms between shots
+  private isWaveTransitioning: boolean = false; // Prevent multiple wave spawns
 
   constructor(
     playerContainer: Container,
@@ -271,10 +272,20 @@ export class GameScene {
 
   private checkWaveCompletion(): void {
     // Check if all enemies are defeated
-    if (this.enemies.length === 0 && this.player.health > 0) {
+    // SPEC § 2.3.5: Wave progression should happen once per wave completion
+    if (
+      this.enemies.length === 0 &&
+      this.player.health > 0 &&
+      !this.isWaveTransitioning
+    ) {
+      // Set flag to prevent multiple wave spawns
+      this.isWaveTransitioning = true;
+
       // Wait a moment before spawning next wave
+      // TODO: Replace with upgrade system (SPEC § 2.3.4)
       setTimeout(() => {
         this.spawnWave(this.currentWave + 1);
+        this.isWaveTransitioning = false;
       }, 2000);
     }
 


### PR DESCRIPTION
## Summary
- 修正 Wave 計算錯誤，防止回合數從 Wave 1 跳到 Wave 56
- 新增 `isWaveTransitioning` 旗標防止重複生成
- 符合 SPEC.md § 2.3.5 Wave System 規格要求

## Changes
- `src/game-scene.ts`: 新增 `isWaveTransitioning` 狀態旗標
- `src/game-scene.ts`: 修正 `checkWaveCompletion()` 方法，防止每個 frame 都創建 setTimeout

Resolves #22

🤖 Generated with [Claude Code](https://claude.ai/code)