### PR TITLE
feat(combat): add tracking range limit for Blood Cake bullets

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -157,6 +157,10 @@ describe("Game Balance Config", () => {
       expect(RECIPE_CONFIG.bloodCake.bloodCake).toBe(3);
     });
 
+    it("豬血糕追蹤範圍應為 500px (Issue #59)", () => {
+      expect(RECIPE_CONFIG.bloodCake.trackingRange).toBe(500);
+    });
+
     it("蚵仔煎百分比傷害應正確 (SPEC § 2.3.3)", () => {
       expect(RECIPE_CONFIG.oysterOmelet.bossDamagePercent).toBe(0.1);
       expect(RECIPE_CONFIG.oysterOmelet.eliteDamagePercent).toBe(0.5);
@@ -173,8 +177,8 @@ describe("Game Balance Config", () => {
       expect(UPGRADE_CONFIG.normal.coconut.bulletBonus).toBe(1);
     });
 
-    it("加香菜應加 0.5 範圍 (SPEC § 2.3.4)", () => {
-      expect(UPGRADE_CONFIG.normal.cilantro.rangeBonus).toBe(0.5);
+    it("加香菜應加 100px 追蹤範圍 (SPEC § 2.3.4)", () => {
+      expect(UPGRADE_CONFIG.normal.cilantro.rangeBonus).toBe(100);
     });
 
     it("大胃王應加 6 彈夾容量 (SPEC § 2.3.4)", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,6 +175,8 @@ export const RECIPE_CONFIG = {
     baseDamage: 2,
     /** 命中減速效果 */
     slowEffect: 0.1, // -10% 敵人移速
+    /** 追蹤範圍 (px) - 基礎範圍約為遊戲區域寬度的 1/3 */
+    trackingRange: 500,
   },
   /** 蚵仔煎 - 百分比傷害 (SPEC § 2.3.3) */
   oysterOmelet: {
@@ -205,7 +207,7 @@ export const UPGRADE_CONFIG = {
     },
     /** 加香菜 - 豬血糕範圍加成 */
     cilantro: {
-      rangeBonus: 0.5,
+      rangeBonus: 100, // +100px per upgrade
       cost: { foodType: "BloodCake" as const, amount: 3 },
     },
   },

--- a/src/systems/combat.ts
+++ b/src/systems/combat.ts
@@ -330,10 +330,18 @@ export class CombatSystem extends InjectableSystem {
 
   /**
    * Find the nearest active enemy to the player
+   * For tracking bullets, applies tracking range limit (SPEC § 2.3.3 + § 2.3.4)
    */
   private findNearestEnemyToPlayer(): Enemy | null {
     if (!this.player) return null;
-    return this.findClosestEnemy(this.player.position);
+
+    // Calculate tracking range with upgrade bonus (SPEC § 2.3.4: 加香菜)
+    const baseRange = RECIPE_CONFIG.bloodCake.trackingRange;
+    const upgradeState = this.upgradeSystem?.getState();
+    const upgradeBonus = upgradeState?.bloodCakeRangeBonus ?? 0;
+    const maxRange = baseRange + upgradeBonus;
+
+    return this.findClosestEnemy(this.player.position, undefined, maxRange);
   }
 
   /**


### PR DESCRIPTION
## 摘要

為豬血糕追蹤彈增加 500px 基礎追蹤範圍，防止追蹤敵人跨越整個畫面。追蹤範圍可透過「加香菜」升級每次增加 100px。

## 變更內容

- 新增 `RECIPE_CONFIG.bloodCake.trackingRange` 配置（500px 基礎範圍）
- 更新「加香菜」升級加成從 0.5 調整為 100px
- 在 `CombatSystem.findNearestEnemyToPlayer()` 實作範圍限制
- 新增測試驗證範圍限制行為

Closes #59

---

Generated with [Claude Code](https://claude.ai/code)