### PR TITLE
fix: 珍珠奶茶散射角度修正為 20 度

### DIFF
--- a/src/systems/combat.ts
+++ b/src/systems/combat.ts
@@ -277,7 +277,7 @@ export class CombatSystem extends InjectableSystem {
     const upgradeBonus = upgradeState?.bubbleTeaBulletBonus ?? 0;
     const totalExtraBullets = baseExtra + upgradeBonus;
 
-    const spreadAngle = 15; // degrees
+    const spreadAngle = 20; // degrees (SPEC § 2.3.3: 珍珠奶茶三向散射，間隔 20 度)
     const bulletType = SpecialBulletType.BubbleTea;
 
     // Center bullet


### PR DESCRIPTION
## 摘要

修正珍珠奶茶子彈散射角度，將原本的 15° 修正為規格要求的 20°。

## 變更說明

- 修改 `src/systems/combat.ts` 中的 `spreadAngle` 從 15° 改為 20°
- 符合 SPEC.md § 2.3.3 規格與 issue #61 要求
- 維持基礎 3 發子彈與升級系統功能

## 測試結果

- ✅ 所有測試通過 (33/33 combat tests)
- ✅ TypeScript 型別檢查通過
- ✅ 建置成功

Closes #61

🤖 Generated with [Claude Code](https://claude.ai/code)