### PR TITLE
feat(synthesis): add edge detection and distinguish ultimate from normal buffs

### DIFF
--- a/src/systems/input.test.ts
+++ b/src/systems/input.test.ts
@@ -161,4 +161,50 @@ describe("InputSystem", () => {
       expect(inputSystem.getMovementDirection().y).toBe(0);
     });
   });
+
+  describe("Synthesis Key Edge Detection", () => {
+    it("應在按鍵首次按下時觸發（edge detection）", () => {
+      // Simulate key press
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "1" }));
+
+      // First frame: should trigger
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(1);
+
+      // Update to mark this frame as processed
+      inputSystem.update(0.016);
+
+      // Second frame (still holding): should NOT trigger
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(null);
+    });
+
+    it("應在按鍵釋放後再按下時再次觸發", () => {
+      // First press
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "2" }));
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(2);
+      inputSystem.update(0.016);
+
+      // Release
+      window.dispatchEvent(new KeyboardEvent("keyup", { key: "2" }));
+      inputSystem.update(0.016);
+
+      // Press again
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "2" }));
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(2);
+    });
+
+    it("應只在當前幀按下的按鍵觸發（多按鍵測試）", () => {
+      // Press key 1
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "1" }));
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(1);
+      inputSystem.update(0.016);
+
+      // Press key 2 while holding key 1
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "2" }));
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(2); // Only key 2 triggers
+      inputSystem.update(0.016);
+
+      // Both keys held: no trigger
+      expect(inputSystem.getSynthesisKeyPressed()).toBe(null);
+    });
+  });
 });

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -11,6 +11,7 @@ export class InputSystem extends InjectableSystem {
   public readonly priority = SystemPriority.INPUT;
 
   private keysPressed: Set<string> = new Set();
+  private prevKeysPressed: Set<string> = new Set();
   private handleKeyDown = (event: KeyboardEvent): void => {
     this.keysPressed.add(event.key.toLowerCase());
   };
@@ -29,10 +30,11 @@ export class InputSystem extends InjectableSystem {
 
   /**
    * Update method (ISystem lifecycle)
-   * InputSystem is event-driven, no update needed
+   * Updates previous key states for edge detection
    */
   public update(_deltaTime: number): void {
-    // Input is event-driven, no per-frame update needed
+    // Update previous key states for edge detection
+    this.prevKeysPressed = new Set(this.keysPressed);
   }
 
   /**
@@ -71,13 +73,15 @@ export class InputSystem extends InjectableSystem {
   /**
    * Check if synthesis key is pressed (1-5)
    * SPEC § 2.3.3: 數字鍵 1-5 直接觸發合成
+   * Uses edge detection to prevent repeated triggering when holding key
    */
   public getSynthesisKeyPressed(): number | null {
-    if (this.keysPressed.has("1")) return 1;
-    if (this.keysPressed.has("2")) return 2;
-    if (this.keysPressed.has("3")) return 3;
-    if (this.keysPressed.has("4")) return 4;
-    if (this.keysPressed.has("5")) return 5;
+    // Edge detection: key was just pressed this frame (not pressed last frame)
+    if (this.keysPressed.has("1") && !this.prevKeysPressed.has("1")) return 1;
+    if (this.keysPressed.has("2") && !this.prevKeysPressed.has("2")) return 2;
+    if (this.keysPressed.has("3") && !this.prevKeysPressed.has("3")) return 3;
+    if (this.keysPressed.has("4") && !this.prevKeysPressed.has("4")) return 4;
+    if (this.keysPressed.has("5") && !this.prevKeysPressed.has("5")) return 5;
     return null;
   }
 
@@ -93,6 +97,7 @@ export class InputSystem extends InjectableSystem {
    */
   public clear(): void {
     this.keysPressed.clear();
+    this.prevKeysPressed.clear();
   }
 
   /**


### PR DESCRIPTION
## 摘要

新增邊緣觸發（Edge Detection）機制，防止按住按鍵時每幀重複觸發合成系統，導致一次扣除多次擊殺數或食材。

## 變更內容

**1. InputSystem 邊緣觸發**：
- 新增 `prevKeysPressed` 狀態追蹤，`getSynthesisKeyPressed()` 只在按鍵從 false → true 時回傳

**2. SynthesisSystem 區分大招與一般 Buff**：
- 大招 (ID 5)：發送 `isUltimate: true` 和 `damageMultiplier`，無 `duration`
- 一般技能 (ID 1-4)：發送 `duration`（從 UpgradeSystem 讀取）

**3. 同步 UpgradeSystem 數據**：
- `getBuffDuration()`：讀取 `buffDurationMultiplier`
- `getOysterDamageMultiplier()`：讀取 `killThresholdDivisor`

**4. 測試案例**：
- 新增 7 個測試案例驗證邊緣觸發和事件數據結構

Related to #78

---

Generated with [Claude Code](https://claude.ai/code)